### PR TITLE
ZQS-512 add release workflow stubs

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,28 @@
+# This workflow is meant to be triggered by push to master when running the release
+# process.
+#
+# Don't extend this workflow. If any more steps are needed please extend the
+# "publish-release" action in "z-quantum-actions". This allows reusing it between repos.
+name: publish-release
+
+# on:
+#   push:
+#     branches:
+#       - master
+
+# jobs:
+#   run-action:
+#     runs-on: ubuntu-latest
+
+#     steps:
+#       # Needed to get access to publish-release action definition
+#       - name: Check out the released repo
+#         uses: actions/checkout@v2
+#         with:
+#           # Fetch whole repo to get access to tags. We need tags to read current package
+#           # version.
+#           fetch-depth: 0
+      
+#       - name: Run publish release action
+#         uses: ./vendor/z-quantum-actions/publish-release
+

--- a/.github/workflows/submit-dev-master-pr.yml
+++ b/.github/workflows/submit-dev-master-pr.yml
@@ -1,0 +1,24 @@
+# This workflow is meant to be triggered by an Operator with via cURL.
+#
+# Don't extend this workflow. If any more steps are needed please extract the steps as a
+# composite action instead. This allows reusing it between repos.
+name: submit-dev-master-pr
+
+# on: 
+#   workflow_dispatch:
+
+# jobs:
+#   submit-pr:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Submit dev -> master PR
+#         uses: actions/github-script@v4
+#         with:
+#           script: |
+#             github.pulls.create({
+#               ...context.repo,
+#               title: "Merge dev to master",
+#               head: "dev",
+#               base: "master",
+#             })
+


### PR DESCRIPTION
Adds workflow stubs required for our release process. The actual workflows will be added on `dev`. This allows us triggering the workflows via GitHub API.